### PR TITLE
Add timestamp mixin to Exhibit

### DIFF
--- a/models/NeatlineExhibit.php
+++ b/models/NeatlineExhibit.php
@@ -39,12 +39,21 @@ class NeatlineExhibit extends Neatline_Row_Expandable
     public $map_restricted_extent;
     public $accessible_url;
 
+    protected function _initializeMixins()
+    {
+        parent::_initializeMixins();
+        $this->_mixins[] = new Mixin_Timestamp($this, 'added', null);
+    }
 
     /**
      * Set exhibit search text.
      */
     protected function afterSave($args)
     {
+        // reinitialize mixins, otherwise a duplicate exhibit will incorrectly populate search text for the original
+        $this->_mixins = [];
+        $this->_initializeMixins();
+
         if ($this->private) {
           $this->setSearchTextPrivate();
         }


### PR DESCRIPTION
### What does this PR do?
Adds Omeka's Timestamp mixin to the Exhibit model, following the example of the CsvImport plugin (https://github.com/omeka/plugin-CsvImport/commit/8a7ade3844749d69051ac37ae8f292b11c943c50) to work around the same MySQL error.

Updated to avoid conflict with other mixins and to prevent incorrect search text setting on duplicated exhibits.

### What issues does it address?
Addresses #400 