### PR TITLE
upgrade version in hookInstall

### DIFF
--- a/NeatlinePlugin.php
+++ b/NeatlinePlugin.php
@@ -43,7 +43,7 @@ class NeatlinePlugin extends Omeka_Plugin_AbstractPlugin
      */
     public function hookInstall()
     {
-        nl_schema243();
+        nl_schema252();
     }
 
 


### PR DESCRIPTION
The schema version referenced during a fresh installation of the Neatline plugin had not been updated to 2.5.2 — this PR fixes that.