### PR TITLE
Make Neatline exhibits and records searchable

### DIFF
--- a/NeatlinePlugin.php
+++ b/NeatlinePlugin.php
@@ -30,7 +30,8 @@ class NeatlinePlugin extends Omeka_Plugin_AbstractPlugin
         'admin_navigation_main',
         'neatline_globals',
         'neatline_presenters',
-        'exhibit_layouts'
+        'exhibit_layouts',
+        'search_record_types'
     );
 
 
@@ -244,5 +245,16 @@ SQL
             'description' => __('Embed a Neatline exhibit.')
         );
         return $layouts;
+    }
+
+
+    /**
+     * Add NeatlineExhibit and NeatlineRecord as searchable types.
+     */
+    public function filterSearchRecordTypes($recordTypes)
+    {
+      $recordTypes['NeatlineExhibit'] = __('Neatline Exhibit');
+      $recordTypes['NeatlineRecord'] = __('Neatline Record');
+      return $recordTypes;
     }
 }

--- a/models/NeatlineExhibit.php
+++ b/models/NeatlineExhibit.php
@@ -38,6 +38,30 @@ class NeatlineExhibit extends Neatline_Row_Expandable
 
 
     /**
+     * Add search visibility for Neatline exhibits.
+     */
+    protected function _initializeMixins()
+    {
+        $this->_mixins[] = new Mixin_Search($this);
+    }
+
+
+    /**
+     * Set exhibit search text.
+     */
+    protected function afterSave($args)
+    {
+        if ($this->private) {
+          $this->setSearchTextPrivate();
+        }
+
+        $this->setSearchTextTitle($this->title);
+        $this->addSearchText($this->title);
+        $this->addSearchText($this->narrative);
+    }
+
+
+    /**
      * If the exhibit is being published to the public site for the first
      * time, set the `published` timestamp.
      *
@@ -81,6 +105,11 @@ class NeatlineExhibit extends Neatline_Row_Expandable
      */
     public function getRecordUrl($action = 'show')
     {
+        if ($action = 'show') {
+          $params = array('action' => $action, 'slug' => $this->slug);
+          return public_url($params, 'neatline');
+        }
+
         $urlHelper = new Omeka_View_Helper_Url;
         $params = array('action' => $action, 'id' => $this->id);
         return $urlHelper->url($params, 'neatlineActionId');

--- a/models/NeatlineRecord.php
+++ b/models/NeatlineRecord.php
@@ -71,6 +71,39 @@ class NeatlineRecord extends Neatline_Row_Expandable
 
 
     /**
+     * Add search visibility for Neatline records.
+     */
+    protected function _initializeMixins()
+    {
+        $this->_mixins[] = new Mixin_Search($this);
+    }
+
+
+    /**
+     * Set record search text.
+     */
+    protected function afterSave($args)
+    {
+        if ($this->private) {
+          $this->setSearchTextPrivate();
+        }
+
+        $this->setSearchTextTitle($this->title);
+        $this->addSearchText($this->title);
+        $this->addSearchText($this->body);
+    }
+
+
+    /**
+     * Generate the URL to be used for the record in search results
+     */
+    public function getRecordUrl($action = 'show')
+    {
+        return $this->getExhibit()->getRecordUrl() . "#records/" . $this->id;
+    }
+
+
+    /**
      * Set exhibit and item references.
      *
      * @param NeatlineExhibit $exhibit The exhibit record.


### PR DESCRIPTION
### What does this PR do?
- adds Neatline exhibits and records to the set of record types that can be enabled in Omeka search settings
- adds after save hooks to set search text and record URL generators to Exhibit and Record models

### What issues does it address?
Closes #396, closes #397 

### How to test
- On [staging](http://neatline-staging.herokuapp.com/), go to Admin -> Settings -> Search and confirm that Neatline Exhibit and Neatline Record appear in the list of available records. Click the check boxes next to these if they are unchecked, then click Save, then click Index.
- Search for existing and newly created Neatline exhibits and records. Text found in an exhibit's title or narrative, or a record's title or body, should be picked up by a search. Try different query types while searching by clicking the '...' next to the search field (note that the default keyword query type will fail to find a result if the search term appears in >50% of records, which can easily be true in test cases).
- Try searching from the admin dashboard and from the public homepage. A Neatline search result from the former should take you to the editor, and a result from the latter should take you to the public exhibit.