### PR TITLE
Add ability to duplicate existing exhibits

### DIFF
--- a/helpers/Acl.php
+++ b/helpers/Acl.php
@@ -74,14 +74,16 @@ function nl_defineAcl($acl)
         'editorSelf',
         'putSelf',
         'importSelf',
-        'deleteSelf'
+        'deleteSelf',
+        'duplicateAll'
     ));
     $acl->allow('contributor', 'Neatline_Exhibits', array(
         'edit',
         'editor',
         'put',
         'import',
-        'delete'
+        'delete',
+        'duplicate'
     ), new Omeka_Acl_Assert_Ownership);
 
     // Contributors can create their own records.

--- a/jobs/Neatline_Job_DuplicateRecords.php
+++ b/jobs/Neatline_Job_DuplicateRecords.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @package     omeka
+ * @subpackage  neatline
+ * @copyright   2014 Rector and Board of Visitors, University of Virginia
+ * @license     http://www.apache.org/licenses/LICENSE-2.0.html
+ */
+
+
+class Neatline_Job_DuplicateRecords extends Omeka_Job_AbstractJob
+{
+
+
+    /**
+     * Duplicate an exhibit's records and assign them to a new exhibit.
+     */
+    public function perform()
+    {
+
+        $_records  = $this->_db->getTable('NeatlineRecord');
+
+        $records = $_records->findBy(array('exhibit_id' => $this->_options['exhibit_id']));
+
+        foreach ($records as $record) {
+          $recordClone = clone $record;
+          $recordClone->exhibit_id = $this->_options['adopting_exhibit_id'];
+          $recordClone->added = date('Y-m-d G:i:s');
+          if ($this->_options['owner_id']) {
+            $recordClone->owner_id = current_user()->id;
+          }
+          $recordClone->save();
+        }
+    }
+
+
+}

--- a/models/NeatlineExhibit.php
+++ b/models/NeatlineExhibit.php
@@ -38,15 +38,6 @@ class NeatlineExhibit extends Neatline_Row_Expandable
 
 
     /**
-     * Add search visibility for Neatline exhibits.
-     */
-    protected function _initializeMixins()
-    {
-        $this->_mixins[] = new Mixin_Search($this);
-    }
-
-
-    /**
      * Set exhibit search text.
      */
     protected function afterSave($args)

--- a/models/NeatlineRecord.php
+++ b/models/NeatlineRecord.php
@@ -71,15 +71,6 @@ class NeatlineRecord extends Neatline_Row_Expandable
 
 
     /**
-     * Add search visibility for Neatline records.
-     */
-    protected function _initializeMixins()
-    {
-        $this->_mixins[] = new Mixin_Search($this);
-    }
-
-
-    /**
      * Set record search text.
      */
     protected function afterSave($args)

--- a/models/abstract/Neatline_Row_Abstract.php
+++ b/models/abstract/Neatline_Row_Abstract.php
@@ -20,6 +20,7 @@ abstract class Neatline_Row_Abstract extends Omeka_Record_AbstractRecord
     protected function _initializeMixins()
     {
         $this->_mixins[] = new Mixin_Owner($this);
+        $this->_mixins[] = new Mixin_Search($this);
     }
 
 

--- a/plugin.php
+++ b/plugin.php
@@ -30,6 +30,7 @@ require_once NL_DIR.'/migrations/2.5.2/Neatline_Migration_252.php';
 
 // Helper classes:
 require_once NL_DIR.'/jobs/Neatline_Job_ImportItems.php';
+require_once NL_DIR.'/jobs/Neatline_Job_DuplicateRecords.php';
 require_once NL_DIR.'/controllers/abstract/Neatline_Controller_Rest.php';
 require_once NL_DIR.'/assertions/Neatline_Acl_Assert_RecordOwnership.php';
 require_once NL_DIR.'/forms/Neatline_Form_Exhibit.php';

--- a/views/admin/exhibits/browse.php
+++ b/views/admin/exhibits/browse.php
@@ -97,6 +97,16 @@
                 </li>
               <?php endif; ?>
 
+              <!-- Duplicate. -->
+              <?php if (is_allowed($e, 'duplicate')): ?>
+                <li>
+                  <?php echo nl_getExhibitLink(
+                    $e, 'duplicate', __('Duplicate'),
+                    array('class' => 'duplicate'), false
+                  ); ?>
+                </li>
+              <?php endif; ?>
+
               <!-- Delete. -->
               <?php if (is_allowed($e, 'delete')): ?>
                 <li>


### PR DESCRIPTION
### What does this PR do?
- Adds a "Duplicate" link to the actions available in the Neatline exhibits admin list
- During duplication, distinguishes the new exhibit with the title suffix " ([username] copy)" and finds a unique slug suffix
- Upon duplication of an exhibit, starts a background job to create copies of all Neatline records attached to the original and attach them to the copy

### What issues does it address?
- Closes #145 

### How to test
- On [staging](http://neatline-staging.herokuapp.com/), log in and go to Neatline admin pane to view the list of exhibits. Under an exhibit, click the "Duplicate" action to copy it. The page should reload with a success message and the new exhibit should appear in the table.
- A duplicate exhibit will initially show 0 in the "# Items" column, since records are copied over asynchronously behind the scenes. After a minute, refreshing the page should cause the number of items to match that of the original exhibit. All other fields should match the original's, except for timestamps ("Created") which should reflect them time of copying.
- Click "Exhibit settings" on the duplicate exhibit and check that the slug has been distinguished from the original's, e.g. "my-exhibit-1"
- Open the duplicate exhibit and check that its records, including those created by importing Omeka items, appear correctly.