### PR TITLE
PHP backward compatibility; Google maps zoom initialization

### DIFF
--- a/models/NeatlineExhibit.php
+++ b/models/NeatlineExhibit.php
@@ -51,7 +51,7 @@ class NeatlineExhibit extends Neatline_Row_Expandable
     protected function afterSave($args)
     {
         // reinitialize mixins, otherwise a duplicate exhibit will incorrectly populate search text for the original
-        $this->_mixins = [];
+        $this->_mixins = array();
         $this->_initializeMixins();
 
         if ($this->private) {

--- a/views/shared/javascripts/src/map/layers/Google/Google.controller.js
+++ b/views/shared/javascripts/src/map/layers/Google/Google.controller.js
@@ -33,19 +33,19 @@ Neatline.module('Map.Layers.Google', function(Google) {
       case 'streets':
         return new OpenLayers.Layer.Google(json.title, {
           type: google.maps.MapTypeId.ROADMAP,
-          numZoomLevels: 19,
+          numZoomLevels: 22,
           useTiltImages: false
         });
       case 'satellite':
         return new OpenLayers.Layer.Google(json.title, {
           type: google.maps.MapTypeId.SATELLITE,
-          numZoomLevels: 19,
+          numZoomLevels: 21,
           useTiltImages: false
         });
       case 'hybrid':
         return new OpenLayers.Layer.Google(json.title, {
           type: google.maps.MapTypeId.HYBRID,
-          numZoomLevels: 19,
+          numZoomLevels: 21,
           useTiltImages: false
         });
       }


### PR DESCRIPTION
### What does this PR do?
Per @jeremyboggs's identification of new array syntax, fixes that usage in the interest of backward compatibility with pre-5.4 versions of PHP.

Also adjusts zoom levels initialization values for Google layer types in OpenLayers, avoiding unnecessary zoom constraint and inconsistent vector layer behavior when zoomed in.

### What issues does it address?
Closes #438, addresses #424 