### PR TITLE
Adjust check for Geolocation plugin in queueing Google Maps API

### DIFF
--- a/helpers/Assets.php
+++ b/helpers/Assets.php
@@ -102,7 +102,7 @@ function nl_queueNeatlinePublic($exhibit)
 function nl_queueNeatlineEditor($exhibit)
 {
 
-    nl_queueGoogleMapsApi();
+    nl_queueGoogleMapsApi(false);
     nl_queueLiveReload();
 
     nl_queueDistCss('neatline-editor');
@@ -163,13 +163,15 @@ function nl_appendScript($script)
 
 /**
  * Include the Google Maps API.
+ *
+ * @param boolean $expectGeolocation If true, check for Geolocation plugin and defer to its Google Maps API instance
  */
-function nl_queueGoogleMapsApi()
+function nl_queueGoogleMapsApi($expectGeolocation = true)
 {
-    // If the Geolocation plugin is installed, and configured with 
+    // If the Geolocation plugin is installed, and configured with
     // a Google API key, it will be injected into the public header,
     // so don't add a key for Neatline.
-    if (get_option('geolocation_api_key')) {
+    if ($expectGeolocation && get_option('geolocation_api_key') && plugin_is_active('Geolocation')) {
         return;
     }
     else {

--- a/views/shared/javascripts/src/map/layers/Google/Google.controller.js
+++ b/views/shared/javascripts/src/map/layers/Google/Google.controller.js
@@ -28,6 +28,7 @@ Neatline.module('Map.Layers.Google', function(Google) {
       case 'physical':
         return new OpenLayers.Layer.Google(json.title, {
           type: google.maps.MapTypeId.TERRAIN,
+          numZoomLevels: 22,
           useTiltImages: false
         });
       case 'streets':


### PR DESCRIPTION
### What does this PR do?
Avoids a 'google not defined' error by adding two additional qualifications to a check for the Geolocation plugin's Google Maps API configuration:
- Geolocation plugin must be activated
- The current view must not be one that won't have the Geolocation plugin's head JS added (i.e. the Neatline exhibit editor)

Also specifies a number of zoom levels in the initialization of the Google Physical map layer type in order to avoid vector layer issues at high zoom levels.

### What issues does it address?
Closes #445 

### How to test
- On [staging](http://neatline-staging.herokuapp.com/admin/neatline), open an exhibit with one or more Google layer types (e.g. [this exhibit](http://neatline-staging.herokuapp.com/admin/neatline/editor/532)) and confirm that the map loads. Open the browser console and check that there isn't an error logged related to multiple API instances or invalid API keys.
- Return to the Neatline admin page and click the exhibit's "public view" link to make the same checks on the map loading in public mode.
- In the main Omeka nav bar at the top right, click "Plugins" and, on the plugins admin page, deactivate the Geolocation plugin. Repeat the checks for map loading in the Neatline exhibits editor and public modes.