### PR TITLE
Added explicit timestamps to the NeatlineRecord model

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
   "require-dev": {
     "phpunit/phpunit": "3.7.*"
+  },
+  "require": {
+    "php": "^5.6.0"
   }
 }

--- a/models/NeatlineRecord.php
+++ b/models/NeatlineRecord.php
@@ -51,6 +51,13 @@ class NeatlineRecord extends Neatline_Row_Expandable
     public $map_zoom;
     public $map_focus;
 
+    protected function _initializeMixins()
+    {
+        parent::_initializeMixins();
+        $this->_mixins[] = new Mixin_Timestamp($this, 'added', null);
+    }
+
+
 
     /**
      * Required style attributes set in `styles.ini`.


### PR DESCRIPTION
### What does this PR do?

Closes #400, by adding explicit timestamps to instances of the NeatlineRecord model before saving, to be compatible with MySQL 5.6+

### How to test

Create a new record in an existing neatline exhibit, then try to save it. It should save without an error.

### Notes

Also adds a requirement for PHP 5.6+ (that version number is purely coincidental, and unrelated to MySQL version number at issue in this PR).