### PR TITLE
Fix neatline_exhibits_browse_default_sort filter

### DIFF
--- a/controllers/ExhibitsController.php
+++ b/controllers/ExhibitsController.php
@@ -70,13 +70,13 @@ class Neatline_ExhibitsController extends Neatline_Controller_Rest
     public function browseAction()
     {
 
+        parent::browseAction();
+
         // By default, sort by added date.
         if (!$this->_getParam('sort_field')) {
             $this->_setParam('sort_field', 'added');
             $this->_setParam('sort_dir', 'd');
         }
-
-        parent::browseAction();
 
     }
 


### PR DESCRIPTION
Call parent's `browseAction` method first so that any Neatline `browse_default_sort` filters will actually be executed.

Fixes #457.