### PR TITLE
Attempt at addressing #497

### DIFF
--- a/controllers/RecordsController.php
+++ b/controllers/RecordsController.php
@@ -29,9 +29,38 @@ class Neatline_RecordsController extends Neatline_Controller_Rest
      */
     public function listAction()
     {
-        echo Zend_Json::encode($this->_records->queryRecords(
-            $this->_request->getParams()
-        ));
+        $params = $this->_request->getParams();
+        foreach ($params as $key=>$val) {
+            switch ($key) {
+                case 'exhibit_id':
+                case 'zoom':
+                case 'limit':
+                case 'start': 
+                    $params[$key] = get_db()->quote($val, "INT");
+                    break;
+                case 'extent':
+                    # do nothing, extent is filtered elsewhere
+                    break;
+                case 'order':
+                    if (!in_array($val, array("id","owner_id","item_id","exhibit_id","added","modified",
+                                            "is_coverage","is_wms","slug","title","item_title","body",
+                                            "coverage","tags","widgets","presenter","fill_color",
+                                            "fill_color_select","stroke_color","stroke_color_select",
+                                            "fill_opacity","fill_opacity_select","stroke_opacity",
+                                            "stroke_opacity_select","stroke_width","point_radius",
+                                            "zindex","weight","start_date","end_date","after_date",
+                                            "before_date","point_image","wms_address","wms_layers",
+                                            "min_zoom","max_zoom","map_zoom","map_focus"))) {
+                        unset($params['order']);
+                    }
+                    break;
+                default:
+                    $params[$key] = get_db()->quote($val);
+                    break;
+            }
+        }
+        $results = $this->_records->queryRecords($params);
+        echo Zend_Json::encode($results);
     }
 
 


### PR DESCRIPTION
This may be overzealous in quoting all input not explicitly dealt with otherwise, but it seems prudent to err on the side of caution. Since the `order` parameter seems to be looking for a column name to use directly, quoting it won't work, so instead I'm validating it against a list of column names from the neatline_records table. This fixes the SQL injection test, and I haven't seen adverse effects, but there may be some in use cases I haven't yet tested.