### PR TITLE
fixed bug with stamen subdomains

### DIFF
--- a/views/shared/javascripts/dist/production/neatline-public.js
+++ b/views/shared/javascripts/dist/production/neatline-public.js
@@ -36900,7 +36900,7 @@ OpenLayers.Rico.Corner = {
             return "$" + e.toLowerCase();
         });
     }
-    var r = "a b c d".split(), s = function(e, t, i, n) {
+    var r = "a b c d".split(" "), s = function(e, t, i, n) {
         return {
             "url": [ "//stamen-tiles-{S}.a.ssl.fastly.net/", e, "/{Z}/{X}/{Y}.", t ].join(""),
             "type": t,


### PR DESCRIPTION
This simple fix addresses #501 by finishing the work begun to address issue #496 on the same problem. 

The updates in that commit failed to add the split separator and the failing stamen urls were coming out as 
https://stamen-tiles-a%20b%20c%20d.a.ssl.fastly.net/watercolor/4/7/7.jpg